### PR TITLE
Disable Before Join

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,50 @@
+<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/AgoraIO-Community/iOS-UIKit/blob/main/CONTRIBUTING.md -->
+
+## Pull request checklist
+
+Please check if your PR fulfills the following requirements:
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
+- [ ] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
+
+
+## Pull request type
+
+<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
+
+<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
+
+Please check the type of change your PR introduces:
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, renaming)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] Documentation content changes
+- [ ] Other (please describe): 
+
+
+## What is the current behavior?
+<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
+
+Issue Number: N/A
+
+
+## What is the new behavior?
+<!-- Please describe the behavior or changes that are being added by this PR. -->
+
+-
+-
+-
+
+## Does this introduce a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+
+
+## Other information
+
+<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

--- a/Agora-AppKit-Example/Agora-AppKit-Example/ViewController.swift
+++ b/Agora-AppKit-Example/Agora-AppKit-Example/ViewController.swift
@@ -15,12 +15,16 @@ class ViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        var agSettings = AgoraSettings()
+        agSettings.cameraEnabled = false
+
         let agoraView = AgoraVideoViewer(
             connectionData: AgoraConnectionData(
                 appId: <#Agora App ID#>,
                 appToken: <#Agora Token or nil#>
             ),
             style: .floating,
+            agoraSettings: agSettings,
             delegate: self
         )
 

--- a/Agora-UIKit-Example/Agora-UIKit-Example/ViewController.swift
+++ b/Agora-UIKit-Example/Agora-UIKit-Example/ViewController.swift
@@ -15,12 +15,15 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        var agSettings = AgoraSettings()
+        agSettings.enabledButtons = [.cameraButton, .micButton, .flipButton]
         let agoraView = AgoraVideoViewer(
             connectionData: AgoraConnectionData(
                 appId: <#Agora App ID#>,
                 appToken: <#Agora Token or nil#>
             ),
             style: .floating,
+            agoraSettings: agSettings,
             delegate: self
         )
 
@@ -65,6 +68,7 @@ extension ViewController: AgoraVideoViewerDelegate {
             systemName: "bolt.fill",
             withConfiguration: UIImage.SymbolConfiguration(scale: .large)
         ), for: .normal)
+        button.backgroundColor = .systemGray
         button.addTarget(self, action: #selector(self.clickedBolt), for: .touchUpInside)
         return [button]
     }

--- a/Sources/Agora-UIKit/AgoraCollectionViewer.swift
+++ b/Sources/Agora-UIKit/AgoraCollectionViewer.swift
@@ -100,8 +100,13 @@ open class AgoraCollectionItem: MPCollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.addSubview(self.backgroundIcon)
-        self.backgroundIcon.frame = CGRect(origin: CGPoint(x: (self.bounds.width - 30) / 2, y: (self.bounds.height - 30) / 2), size: CGSize(width: 30, height: 30))
-        self.backgroundIcon.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin, .flexibleBottomMargin]
+        self.backgroundIcon.frame = CGRect(
+            origin: CGPoint(x: (self.bounds.width - 30) / 2, y: (self.bounds.height - 30) / 2),
+            size: CGSize(width: 30, height: 30)
+        )
+        self.backgroundIcon.autoresizingMask = [
+            .flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin, .flexibleBottomMargin
+        ]
     }
 
     /// Create view from NSCoder, not yet implemented.
@@ -118,7 +123,11 @@ open class AgoraCollectionItem: MPCollectionViewCell {
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.lightGray.cgColor
         self.view.addSubview(self.backgroundIcon)
-        self.backgroundIcon.frame = CGRect(origin: CGPoint(x: (self.view.bounds.width - 50) / 2, y: (self.view.bounds.height - 50) / 2), size: CGSize(width: 50, height: 50))
+        self.backgroundIcon.frame = CGRect(
+            origin: CGPoint(x: (self.view.bounds.width - 50) / 2,
+                            y: (self.view.bounds.height - 50) / 2),
+            size: CGSize(width: 50, height: 50)
+        )
         self.backgroundIcon.autoresizingMask = [.maxXMargin, .minXMargin, .maxYMargin, .minYMargin]
      }
     #endif

--- a/Sources/Agora-UIKit/AgoraSettings.swift
+++ b/Sources/Agora-UIKit/AgoraSettings.swift
@@ -75,6 +75,14 @@ public struct AgoraSettings {
         }
     }
 
+    /// If the camera is enabled. Set this before joining a channel to not require camera permissions
+    /// and camera to not be activated at all.
+    public var cameraEnabled: Bool = true
+
+    /// If the microphone is enabled. Set this before joining a channel to not require microphone permissions
+    /// and mic to not be activated at all.
+    public var micEnabled: Bool = true
+
     /// Maximum number of videos in the grid view before the low bitrate is adopted.
     public var gridThresholdHighBitrate: Int = 4
 

--- a/Sources/Agora-UIKit/AgoraSettings.swift
+++ b/Sources/Agora-UIKit/AgoraSettings.swift
@@ -104,7 +104,7 @@ public struct AgoraSettings {
     static var buttonIconScale: UIImage.SymbolScale = .large
     #else
     /// Font size of the builtin buttons SF Symbol text
-    static var buttonIconSize: CGFloat = 50
+    static var buttonIconSize: CGFloat = 20
     #endif
 }
 

--- a/Sources/Agora-UIKit/AgoraSettings.swift
+++ b/Sources/Agora-UIKit/AgoraSettings.swift
@@ -94,10 +94,36 @@ public struct AgoraSettings {
         "width":160,"height":120,"frameRate":5,"bitRate":45
       }}
     """
+
+    /// Size of buttons that will appear in the builtin button tray
+    var buttonSize: CGFloat = 60
+    /// Margin around each button in the builtin button tray
+    var buttonMargin: CGFloat = 5
+    #if os(iOS)
+    /// Scale of the icons within the buttons in the builtin button tray
+    static var buttonIconScale: UIImage.SymbolScale = .large
+    #else
+    /// Font size of the builtin buttons SF Symbol text
+    static var buttonIconSize: CGFloat = 50
+    #endif
 }
 
 /// Colors for views inside AgoraVideoViewer
 public struct AgoraViewerColors {
     /// Color of the view that signals a user has their mic muted. Default `.systemBlue`
     public var micFlag: MPColor = .systemBlue
+    /// Color of the mute mic button when in unselected state (not muted)
+    public var micButtonNormal: MPColor = .systemGreen
+    /// Color of the mute cam button when in unselected state (camera on)
+    public var camButtonNormal: MPColor = .systemGreen
+    /// Color of the mute mic button when in selected state (muted)
+    public var micButtonSelected: MPColor = .systemRed
+    /// Color of the mute cam button when in selected state (camera off)
+    public var camButtonSelected: MPColor = .systemRed
+    /// Color of the bar button when in unselected state
+    public var buttonDefaultNormal: MPColor = .systemGray
+    /// Color of the bar button when in selected state
+    public var buttonDefaultSelected: MPColor = .systemRed
+    /// Tint color of all buttons that appear in the bottom bar
+    public var buttonTintColor: MPColor = .systemBlue
 }

--- a/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
@@ -141,7 +141,9 @@ extension AgoraVideoViewer {
         if !self.agoraSettings.enabledButtons.contains(.cameraButton) { return nil }
         if let camButton = self.camButton { return camButton }
 
-        let button = MPButton.newToggleButton(unselected: MPButton.videoSymbol, selected: MPButton.muteVideoSelectedSymbol)
+        let button = MPButton.newToggleButton(
+            unselected: MPButton.videoSymbol, selected: MPButton.muteVideoSelectedSymbol
+        )
         #if os(iOS)
         button.addTarget(self, action: #selector(toggleCam), for: .touchUpInside)
         #else

--- a/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
@@ -66,21 +66,27 @@ extension AgoraVideoViewer {
             case .left, .right:
                 button.frame.origin.y += (buttonMargin + buttonSize) * CGFloat(elem.offset)
             }
-                #if os(iOS)
-                button.layer.cornerRadius = buttonSize / 2
-                if elem.offset < builtinButtons.count {
-                    button.backgroundColor = self.agoraSettings.colors.buttonDefaultNormal
-                    button.tintColor = self.agoraSettings.colors.buttonTintColor
-                }
-                #else
-                button.isBordered = false
-                button.layer?.cornerRadius = buttonSize / 2
-                if elem.offset < builtinButtons.count {
-                    button.layer?.backgroundColor = self.agoraSettings.colors.buttonDefaultNormal.cgColor
-                    button.contentTintColor = self.agoraSettings.colors.buttonTintColor
-                }
-                #endif
+            #if os(iOS)
+            button.layer.cornerRadius = buttonSize / 2
+            if elem.offset < builtinButtons.count {
+                button.backgroundColor = self.agoraSettings.colors.buttonDefaultNormal
+                button.tintColor = self.agoraSettings.colors.buttonTintColor
+            }
+            #else
+            button.isBordered = false
+            button.layer?.cornerRadius = buttonSize / 2
+            if elem.offset < builtinButtons.count {
+                button.layer?.backgroundColor = self.agoraSettings.colors.buttonDefaultNormal.cgColor
+                button.contentTintColor = self.agoraSettings.colors.buttonTintColor
+            }
+            #endif
         })
+        self.setCamAndMicButtons()
+        let contWidth = CGFloat(buttons.count) * (buttonSize + buttonMargin) + buttonMargin
+        positionButtonContainer(container, contWidth, buttonMargin)
+    }
+
+    internal func setCamAndMicButtons() {
         self.camButton?.isOn = !self.agoraSettings.cameraEnabled
         self.micButton?.isOn = !self.agoraSettings.micEnabled
         #if os(iOS)
@@ -106,8 +112,6 @@ extension AgoraVideoViewer {
             swap(&micbtn.title, &micbtn.alternateTitle)
         }
         #endif
-        let contWidth = CGFloat(buttons.count) * (buttonSize + buttonMargin) + buttonMargin
-        positionButtonContainer(container, contWidth, buttonMargin)
     }
 
     internal func getControlContainer() -> MPBlurView {

--- a/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
@@ -105,10 +105,10 @@ extension AgoraVideoViewer {
                 ? self.agoraSettings.colors.micButtonNormal
                 : self.agoraSettings.colors.micButtonSelected
         ).cgColor
-        if let cambtn = self.camButton, cambtn.isOn, cambtn.alternateTitle != "" {
+        if let cambtn = self.camButton, cambtn.isOn, !cambtn.alternateTitle.isEmpty {
             swap(&cambtn.title, &cambtn.alternateTitle)
         }
-        if let micbtn = self.micButton, micbtn.isOn, micbtn.alternateTitle != "" {
+        if let micbtn = self.micButton, micbtn.isOn, !micbtn.alternateTitle.isEmpty {
             swap(&micbtn.title, &micbtn.alternateTitle)
         }
         #endif

--- a/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+Buttons.swift
@@ -74,6 +74,16 @@ extension AgoraVideoViewer {
             button.layer?.backgroundColor = NSColor.systemGray.cgColor
             #endif
         })
+        [(self.camButton, !self.agoraSettings.cameraEnabled),
+         (self.micButton, !self.agoraSettings.micEnabled)
+        ].forEach { (button, isOn) in
+            button?.isOn = isOn
+            #if os(iOS)
+            button?.backgroundColor = isOn ? .systemRed : .systemGray
+            #else
+            button?.layer?.backgroundColor = isOn ? NSColor.systemRed.cgColor : NSColor.systemGray.cgColor
+            #endif
+        }
         let contWidth = CGFloat(buttons.count) * (60 + buttonMargin) + buttonMargin
         positionButtonContainer(container, contWidth, buttonMargin)
     }

--- a/Sources/Agora-UIKit/AgoraVideoViewer+Permissions.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+Permissions.swift
@@ -23,7 +23,11 @@ extension AgoraVideoViewer {
     ///                  the current permission (default true)
     ///   - callback: Method to call once the requests have been made - if alsoRequest set to true.
     /// - Returns: True if camera and microphone are authorised.
-    public func checkForPermissions(_ requiredMediaTypes: [AVMediaType], alsoRequest: Bool = true, callback: ((Error?) -> Void)? = nil) -> Bool {
+    public func checkForPermissions(
+        _ requiredMediaTypes: [AVMediaType],
+        alsoRequest: Bool = true,
+        callback: ((Error?) -> Void)? = nil
+    ) -> Bool {
         for mediaType in requiredMediaTypes {
             if !self.checkPermissions(for: mediaType, alsoRequest: alsoRequest, callback: callback) {
                 return false
@@ -32,7 +36,11 @@ extension AgoraVideoViewer {
         return true
     }
 
-    internal func checkPermissions(for mediaType: AVMediaType, alsoRequest: Bool = true, callback: ((Error?) -> Void)? = nil) -> Bool {
+    internal func checkPermissions(
+        for mediaType: AVMediaType,
+        alsoRequest: Bool = true,
+        callback: ((Error?) -> Void)? = nil
+    ) -> Bool {
         switch AVCaptureDevice.authorizationStatus(for: mediaType) {
         case .authorized: break
         case .notDetermined:

--- a/Sources/Agora-UIKit/AgoraVideoViewer+Permissions.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+Permissions.swift
@@ -18,28 +18,31 @@ import AppKit
 extension AgoraVideoViewer {
     /// Helper function to check if we currently have permission to use the camera and microphone
     /// - Parameters:
+    ///   - requiredMediaTypes: Array of media devices required by the permissions (camera and microphone usually)
     ///   - alsoRequest: True if we want to also request permission, false if we just want
     ///                  the current permission (default true)
     ///   - callback: Method to call once the requests have been made - if alsoRequest set to true.
     /// - Returns: True if camera and microphone are authorised.
-    public func checkForPermissions(alsoRequest: Bool = true, callback: (() -> Void)? = nil) -> Bool {
-        if !self.checkCameraPermissions(alsoRequest: alsoRequest, callback: callback) ||
-            !self.checkMicPermissions(alsoRequest: alsoRequest, callback: callback) {
-            return false
+    public func checkForPermissions(_ requiredMediaTypes: [AVMediaType], alsoRequest: Bool = true, callback: ((Error?) -> Void)? = nil) -> Bool {
+        for mediaType in requiredMediaTypes {
+            if !self.checkPermissions(for: mediaType, alsoRequest: alsoRequest, callback: callback) {
+                return false
+            }
         }
         return true
     }
 
-    func checkMicPermissions(alsoRequest: Bool = true, callback: (() -> Void)? = nil) -> Bool {
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+    internal func checkPermissions(for mediaType: AVMediaType, alsoRequest: Bool = true, callback: ((Error?) -> Void)? = nil) -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: mediaType) {
         case .authorized: break
         case .notDetermined:
             if alsoRequest {
-                AgoraVideoViewer.requestMicrophoneAccess { success in
-                    if success {
-                        callback?()
+                AVCaptureDevice.requestAccess(for: mediaType) { granted in
+                    if granted {
+                        callback?(nil)
                     } else {
                         AgoraVideoViewer.errorVibe()
+                        callback?(PermissionError.permissionDenied)
                     }
                 }
             }
@@ -52,46 +55,14 @@ extension AgoraVideoViewer {
         }
         return true
     }
-
-    func checkCameraPermissions(alsoRequest: Bool = true, callback: (() -> Void)? = nil) -> Bool {
-        switch AVCaptureDevice.authorizationStatus(for: .video) {
-        case .authorized: break
-        case .notDetermined:
-            if alsoRequest {
-                AgoraVideoViewer.requestCameraAccess { success in
-                    if success {
-                        callback?()
-                    } else {
-                        AgoraVideoViewer.errorVibe()
-                    }
-                }
-            }
-            return false
-        default:
-            if alsoRequest {
-                cameraMicSettingsPopup {
-                    AgoraVideoViewer.goToSettingsPage()
-                }
-            }
-            return false
-        }
-        return true
-    }
-
-    /// Request access to use the camera.
-    /// - Parameter handler: A block to be called once permission is granted or denied.
-    public static func requestCameraAccess(handler: ((Bool) -> Void)? = nil) {
-        AVCaptureDevice.requestAccess(for: .video) { granted in
-            handler?(granted)
-        }
-    }
-
-    /// Request access to use the microphone.
-    /// - Parameter handler: A block to be called once permission is granted or denied.
-    public static func requestMicrophoneAccess(handler: ((Bool) -> Void)? = nil) {
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
-            handler?(granted)
-        }
+    /// Error that may come back due to permissions failing
+    public enum PermissionError: Error {
+        /// User just refused permissions after Apple's popup
+        case permissionDenied
+        /// User has refused the permissions before
+        case permissionAlreadyDenied
+        /// User has not yet granted or refused permissions
+        case notDetermined
     }
 
     /// Head to the device security page.

--- a/Sources/Agora-UIKit/AgoraVideoViewer+Utilities.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+Utilities.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public extension AgoraVideoViewer {
+extension AgoraVideoViewer {
     /// Print level that will be visible in the developer console, default `.error`
     static var printLevel: PrintType = .warning
     /// Level for an internal print statement
@@ -34,6 +34,22 @@ public extension AgoraVideoViewer {
         if tag.rawValue <= AgoraVideoViewer.printLevel.rawValue {
             print("[AgoraVideoViewer \(tag.printString)]: \(message)")
         }
+        #endif
+    }
+
+    /// Helper method to fill a view with this view
+    /// - Parameter view: view to fill with self
+    open func fills(view: MPView) {
+        view.addSubview(self)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        #if os(iOS)
+        self.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        self.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        self.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        self.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        #else
+        self.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
+        self.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
         #endif
     }
 }

--- a/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
@@ -99,7 +99,7 @@ extension AgoraVideoViewer {
         camButton.backgroundColor = camButton.isOn
             ? self.agoraSettings.colors.camButtonSelected : self.agoraSettings.colors.camButtonNormal
         #else
-        if camButton.alternateTitle != "" {
+        if !camButton.alternateTitle.isEmpty {
             swap(&camButton.title, &camButton.alternateTitle)
         }
         camButton.layer?.backgroundColor = (
@@ -137,7 +137,7 @@ extension AgoraVideoViewer {
         micButton.backgroundColor = micButton.isOn
             ? self.agoraSettings.colors.micButtonSelected : self.agoraSettings.colors.micButtonNormal
         #else
-        if micButton.alternateTitle != "" {
+        if !micButton.alternateTitle.isEmpty {
             swap(&micButton.title, &micButton.alternateTitle)
         }
         micButton.layer?.backgroundColor = (

--- a/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
@@ -21,38 +21,124 @@ extension AgoraVideoViewer {
         self.agkit.setVideoEncoderConfiguration(self.agoraSettings.videoConfiguration)
     }
 
-    /// Toggle the camera between on and off
-    @objc open func toggleCam() {
-        guard let camButton = self.getCameraButton() else {
+    /// Manually set the camera to be enabled or disabled.
+    /// This method will check for the camera enable/disable button to change its state.
+    /// - Parameter isEnabled: Should the camera be enabled.
+    /// - Returns: Boolean stating whether it was successful or not.
+    open func setCameraEnabled(_ isEnabled: Bool) -> Bool {
+        if isEnabled == self.agoraSettings.cameraEnabled {
+            // no change
+            return true
+        }
+        if self.connectionData.channel == nil {
+            // we are not yet in a channel, no permissions required
+            self.agoraSettings.cameraEnabled = isEnabled
+            return true
+        }
+        // we are in a channel
+        if isEnabled {
+            if !self.checkForPermissions([.video]) {
+                // permissions are not or were not granted,
+                // allow permissions then call again
+                return false
+            }
+        }
+        self.agoraSettings.cameraEnabled = isEnabled
+        self.toggleCam(nil)
+        return true
+    }
+    /// Manually set the microphone to be enabled or disabled.
+    /// This method will check for the microphone enable/disable button to change its state.
+    /// - Parameter isEnabled: Should the microphone be enabled.
+    /// - Returns: Boolean stating whether it was successful or not.
+    open func setMicEnabled(_ isEnabled: Bool, completion: @escaping (Bool) -> Void) {
+        if isEnabled == self.agoraSettings.micEnabled {
+            // no change
             return
         }
+        if self.connectionData.channel == nil {
+            // we are not yet in a channel, no permissions required
+            self.agoraSettings.micEnabled = isEnabled
+            completion(true)
+            return
+        }
+        // we are in a channel
+        if isEnabled {
+            if !self.checkForPermissions([.audio], callback: { error in
+                completion(error == nil)
+            }) { return }
+        }
+        self.toggleMic(self.micButton)
+    }
+
+    /// Toggle the camera between on and off
+    /// - Parameter sender: The sender is typically the camera button
+    @objc open func toggleCam(_ sender: MPButton?) {
+        guard let camButton = sender ?? self.camButton else {
+            return
+        }
+        if sender != nil {
+            if !self.agoraSettings.cameraEnabled,
+               self.connectionData.channel != nil,
+               !self.checkPermissions(
+                for: .video,
+                callback: { err in
+                    if err == nil {
+                        DispatchQueue.main.async {
+                            // if permissions are now granted
+                            self.toggleCam(sender)
+                        }
+                    }
+                }) {
+                return
+            }
+            self.agoraSettings.cameraEnabled.toggle()
+        }
         #if os(iOS)
-        camButton.isSelected.toggle()
         camButton.backgroundColor = camButton.isSelected ? .systemRed : .systemGray
-        self.agkit.enableLocalVideo(!camButton.isSelected)
         #else
         camButton.layer?.backgroundColor = camButton.isOn ?
             NSColor.systemRed.cgColor : NSColor.systemGray.cgColor
-        self.agkit.enableLocalVideo(!camButton.isOn)
         #endif
+        camButton.isOn = !self.agoraSettings.cameraEnabled
+        self.agkit.enableLocalVideo(!camButton.isOn)
     }
 
     /// Toggle the microphone between on and off
-    @objc open func toggleMic() {
-        guard let micButton = self.getMicButton() else {
+    /// - Parameter sender: The sender is typically the microphone button
+    @objc open func toggleMic(_ sender: MPButton?) {
+        guard let micButton = sender ?? self.micButton else {
             return
         }
+        if !self.agoraSettings.micEnabled,
+           self.connectionData.channel != nil,
+           !self.checkPermissions(
+            for: .audio,
+            callback: { err in
+                if err == nil {
+                    DispatchQueue.main.async {
+                        // if permissions are now granted
+                        self.toggleMic(sender)
+                    }
+                }
+            }) {
+            return
+        }
+        self.agoraSettings.micEnabled.toggle()
+        micButton.isOn = !self.agoraSettings.micEnabled
         #if os(iOS)
-        micButton.isSelected.toggle()
         micButton.backgroundColor = micButton.isSelected ? .systemRed : .systemGray
-        self.agkit.muteLocalAudioStream(micButton.isSelected)
-        self.userVideoLookup[self.userID]?.audioMuted = micButton.isSelected
         #else
-        micButton.layer?.backgroundColor = (micButton.isOn ?
-                                              NSColor.systemRed : NSColor.systemGray).cgColor
-        self.agkit.muteLocalAudioStream(micButton.isOn)
-        self.userVideoLookup[self.userID]?.audioMuted = micButton.isOn
+        micButton.layer?.backgroundColor = (
+            micButton.isOn ? NSColor.systemRed : NSColor.systemGray
+        ).cgColor
         #endif
+        self.userVideoLookup[self.userID]?.audioMuted = micButton.isOn
+        self.agkit.muteLocalAudioStream(micButton.isOn)
+        if !micButton.isOn {
+            // This is only enabled. If you want to disable it then do so manually.
+            self.agkit.enableLocalAudio(true)
+        }
     }
 
     /// Turn screen sharing on/off
@@ -127,17 +213,29 @@ extension AgoraVideoViewer {
         self.setRole(to: self.userRole == .broadcaster ? .audience : .broadcaster)
     }
 
+    internal var activePermissions: [AVMediaType] {
+        var rtnMedias = [AVMediaType]()
+        if self.agoraSettings.micEnabled { rtnMedias.append(.audio) }
+        if self.agoraSettings.cameraEnabled { rtnMedias.append(.video) }
+        return rtnMedias
+    }
+
     /// Change the role of the local user when connecting to a channel
     /// - Parameter role: new role for the local user.
     public func setRole(to role: AgoraClientRole) {
         // Check if we have access to mic + camera
         // before changing the user role.
-        if role == .broadcaster, !self.checkForPermissions(callback: {
-            if self.checkForPermissions(alsoRequest: false) {
-                self.setRole(to: role)
+        if role == .broadcaster {
+            if !self.checkForPermissions(self.activePermissions, callback: { error in
+                if error != nil {
+                    return
+                }
+                if self.checkForPermissions(self.activePermissions, alsoRequest: false) {
+                    self.setRole(to: role)
+                }
+            }) {
+                return
             }
-        }) {
-            return
         }
 
         // Swap the userRole
@@ -202,7 +300,10 @@ extension AgoraVideoViewer {
             fatalError("No app ID is provided")
         }
         if role == .broadcaster {
-            if !self.checkForPermissions(callback: {
+            if !self.checkForPermissions(self.activePermissions, callback: { error in
+                if error != nil {
+                    return
+                }
                 DispatchQueue.main.async {
                     self.join(channel: channel, with: token, as: role, uid: uid)
                 }
@@ -229,6 +330,12 @@ extension AgoraVideoViewer {
         self.currentToken = token
         self.setupAgoraVideo()
         self.connectionData.channel = channel
+        if !self.agoraSettings.cameraEnabled {
+            self.agkit.enableLocalVideo(false)
+        }
+        if !self.agoraSettings.micEnabled {
+            self.agkit.enableLocalAudio(false)
+        }
         self.agkit.joinChannel(
             byToken: token,
             channelId: channel,

--- a/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
@@ -94,13 +94,20 @@ extension AgoraVideoViewer {
             }
             self.agoraSettings.cameraEnabled.toggle()
         }
-        #if os(iOS)
-        camButton.backgroundColor = camButton.isSelected ? .systemRed : .systemGray
-        #else
-        camButton.layer?.backgroundColor = camButton.isOn ?
-            NSColor.systemRed.cgColor : NSColor.systemGray.cgColor
-        #endif
         camButton.isOn = !self.agoraSettings.cameraEnabled
+        #if os(iOS)
+        camButton.backgroundColor = camButton.isOn
+            ? self.agoraSettings.colors.camButtonSelected : self.agoraSettings.colors.camButtonNormal
+        #else
+        if camButton.alternateTitle != "" {
+            swap(&camButton.title, &camButton.alternateTitle)
+        }
+        camButton.layer?.backgroundColor = (
+            camButton.isOn
+                ? self.agoraSettings.colors.camButtonSelected
+                : self.agoraSettings.colors.camButtonNormal
+        ).cgColor
+        #endif
         self.agkit.enableLocalVideo(!camButton.isOn)
     }
 
@@ -127,10 +134,16 @@ extension AgoraVideoViewer {
         self.agoraSettings.micEnabled.toggle()
         micButton.isOn = !self.agoraSettings.micEnabled
         #if os(iOS)
-        micButton.backgroundColor = micButton.isSelected ? .systemRed : .systemGray
+        micButton.backgroundColor = micButton.isOn
+            ? self.agoraSettings.colors.micButtonSelected : self.agoraSettings.colors.micButtonNormal
         #else
+        if micButton.alternateTitle != "" {
+            swap(&micButton.title, &micButton.alternateTitle)
+        }
         micButton.layer?.backgroundColor = (
-            micButton.isOn ? NSColor.systemRed : NSColor.systemGray
+            micButton.isOn
+                ? self.agoraSettings.colors.micButtonSelected
+                : self.agoraSettings.colors.micButtonNormal
         ).cgColor
         #endif
         self.userVideoLookup[self.userID]?.audioMuted = micButton.isOn

--- a/Sources/Agora-UIKit/AgoraVideoViewer.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer.swift
@@ -312,22 +312,6 @@ open class AgoraVideoViewer: MPView {
         }
     }
 
-    /// Helper method to fill a view with this view
-    /// - Parameter view: view to fill with self
-    open func fills(view: MPView) {
-        view.addSubview(self)
-        self.translatesAutoresizingMaskIntoConstraints = false
-        #if os(iOS)
-        self.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
-        self.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-        self.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
-        self.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
-        #else
-        self.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
-        self.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
-        #endif
-    }
-
     /// Container for the buttons (such as mute, flip camera etc.)
     public var controlContainer: MPBlurView?
     var camButton: MPButton?
@@ -345,59 +329,4 @@ open class AgoraVideoViewer: MPView {
     }()
 
     var remoteUserIDs: Set<UInt> = []
-
-    @discardableResult
-    internal func addLocalVideo() -> AgoraSingleVideoView? {
-        if self.userID == 0 || self.userVideoLookup[self.userID] != nil {
-            return self.userVideoLookup[self.userID]
-        }
-        let vidView = AgoraSingleVideoView(uid: self.userID, micColor: self.agoraSettings.colors.micFlag)
-        vidView.canvas.renderMode = self.agoraSettings.videoRenderMode
-        self.agkit.setupLocalVideo(vidView.canvas)
-        self.userVideoLookup[self.userID] = vidView
-        return vidView
-    }
-
-    /// Create AgoraSingleVideoView for the requested userID
-    /// - Parameters:
-    ///   - userId: User ID of the feed to be displayed in the view
-    /// - Returns: The newly created view, or an existing one for the same userID.
-    @discardableResult
-    open func addUserVideo(with userId: UInt) -> AgoraSingleVideoView {
-        if let remoteView = self.userVideoLookup[userId] {
-            return remoteView
-        }
-        let remoteVideoView = AgoraSingleVideoView(uid: userId, micColor: self.agoraSettings.colors.micFlag)
-        remoteVideoView.canvas.renderMode = self.agoraSettings.videoRenderMode
-        self.agkit.setupRemoteVideo(remoteVideoView.canvas)
-        self.userVideoLookup[userId] = remoteVideoView
-        if self.activeSpeaker == nil {
-            self.activeSpeaker = userId
-        }
-        return remoteVideoView
-    }
-
-    /// Randomly select an activeSpeaker that is not the local user
-    open func setRandomSpeaker() {
-        if let randomNotMe = self.userVideoLookup.keys.shuffled().filter({ $0 != self.userID }).randomElement() {
-            // active speaker has left, reassign activeSpeaker to a random member
-            self.activeSpeaker = randomNotMe
-        } else {
-            self.activeSpeaker = nil
-        }
-    }
-
-    func removeUserVideo(with userId: UInt) {
-        guard let userSingleView = userVideoLookup[userId],
-              let canView = userSingleView.canvas.view else {
-            return
-        }
-        self.agkit.muteRemoteVideoStream(userId, mute: true)
-        userSingleView.canvas.view = nil
-        canView.removeFromSuperview()
-        self.userVideoLookup.removeValue(forKey: userId)
-        if let activeSpeaker = self.activeSpeaker, activeSpeaker == userId {
-            self.setRandomSpeaker()
-        }
-    }
 }

--- a/Sources/Agora-UIKit/AgoraVideoViewer.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer.swift
@@ -250,9 +250,9 @@ open class AgoraVideoViewer: MPView {
         connectionData: AgoraConnectionData, style: AgoraVideoViewer.Style = .grid,
         agoraSettings: AgoraSettings = AgoraSettings(), delegate: AgoraVideoViewerDelegate? = nil
     ) {
+        self.agoraSettings = agoraSettings
         self.connectionData = connectionData
         self.style = style
-        self.agoraSettings = agoraSettings
         self.delegate = delegate
         super.init(frame: .zero)
     }

--- a/Sources/Agora-UIKit/UIButton+Extensions.swift
+++ b/Sources/Agora-UIKit/UIButton+Extensions.swift
@@ -11,7 +11,7 @@ import UIKit
 import AppKit
 #endif
 
-internal extension MPButton {
+extension MPButton {
     /// Create a custom UI/NSButton made up of one or two SF Symbol images to alternate between
     /// - Parameters:
     ///   - unselected: SF Symbol present by default, when button has not yet been selected
@@ -28,47 +28,71 @@ internal extension MPButton {
             #if os(iOS)
             button.setImage(MPImage(
                 systemName: selected,
-                withConfiguration: MPImage.SymbolConfiguration(scale: .large)
+                withConfiguration: MPImage.SymbolConfiguration(scale: AgoraSettings.buttonIconScale)
             ), for: .selected)
             #else
-            button.title = selected
+            button.alternateTitle = selected
             #endif
         }
         #if os(iOS)
         button.setImage(MPImage(
             systemName: unselected,
-            withConfiguration: MPImage.SymbolConfiguration(scale: .large)
+            withConfiguration: MPImage.SymbolConfiguration(scale: AgoraSettings.buttonIconScale)
         ), for: .normal)
         #else
         button.title = unselected
+        print(NSFont.systemFontSize)
+        button.font = .systemFont(ofSize: AgoraSettings.buttonIconSize)
         #endif
         return button
     }
 
     #if os(iOS)
-    static var videoSymbol = "video"
-    static var videoSlashSymbol = "video.slash"
-    static var micSymbol = "mic"
-    static var micSlashSymbol = "mic.slash"
-    static var cameraRotateSymbol = "camera.rotate"
-    static var wandSymbol = "wand.and.stars.inverse"
-    static var personSymbol = "person.circle"
-    static var screenShareSymbol = "rectangle.on.rectangle"
-    static var pinSymbol = "pin.fill"
-    var isOn: Bool {
+    /// SF Symbol name for camera icon for builtin button
+    public static var videoSymbol = "camera.fill"
+    /// SF Symbol name for camera alt icon for builtin button
+    public static var muteVideoSelectedSymbol: String? = nil
+    /// SF Symbol name for microphone icon for builtin button
+    public static var micSymbol = "mic"
+    /// SF Symbol name for microphone alt icon for builtin button
+    public static var muteMicSelectedSymbol: String? = "mic.slash"
+    /// SF Symbol name for microphone muted flag
+    public static var micSlashSymbol = "mic.slash"
+    /// SF Symbol name for flip camera builtin button
+    public static var cameraRotateSymbol = "camera.rotate"
+    /// SF Symbol name for beautify buitlin button
+    public static var wandSymbol = "wand.and.stars.inverse"
+    /// SF Symbol name to appear behind user with camera off
+    public static var personSymbol = "person.circle"
+    /// SF Symbol name for sharing screen builtin button
+    public static var screenShareSymbol = "rectangle.on.rectangle"
+    /// SF Symbol name for pin icon
+    public static var pinSymbol = "pin.fill"
+    internal var isOn: Bool {
         get { self.isSelected }
         set { self.isSelected = newValue }
     }
     #else
-    static var videoSymbol = "􀍉"
-    static var videoSlashSymbol = "􀍍"
-    static var micSymbol = "􀊰"
-    static var micSlashSymbol = "􀊲"
-    static var cameraRotateSymbol = "􀌢"
-    static var wandSymbol = "􀜎"
-    static var personSymbol = "􀓣"
-    static var screenShareSymbol = "􀏧"
-    static var pinSymbol = "􀎧"
+    /// SF Symbol name for camera icon for builtin button
+    public static var videoSymbol = "􀌟"
+    /// SF Symbol name for camera alt icon for builtin button
+    public static var muteVideoSelectedSymbol: String? = nil
+    /// SF Symbol name for microphone icon for builtin button
+    public static var micSymbol = "􀊰"
+    /// SF Symbol for microphone alt icon for builtin button
+    public static var muteMicSelectedSymbol: String? = "􀊲"
+    /// SF Symbol for microphone muted flag
+    public static var micSlashSymbol = "􀊲"
+    /// SF Symbol for flip camera builtin button
+    public static var cameraRotateSymbol = "􀌢"
+    /// SF Symbol for beautify buitlin button
+    public static var wandSymbol = "􀜎"
+    /// SF Symbol to appear behind user with camera off
+    public static var personSymbol = "􀓣"
+    /// SF Symbol for sharing screen builtin button
+    public static var screenShareSymbol = "􀏧"
+    /// SF Symbol for pin icon
+    public static var pinSymbol = "􀎧"
     var isOn: Bool {
         get { return self.state == .on }
         set { self.state = newValue ? .on : .off }

--- a/Sources/Agora-UIKit/UIButton+Extensions.swift
+++ b/Sources/Agora-UIKit/UIButton+Extensions.swift
@@ -55,6 +55,10 @@ internal extension MPButton {
     static var personSymbol = "person.circle"
     static var screenShareSymbol = "rectangle.on.rectangle"
     static var pinSymbol = "pin.fill"
+    var isOn: Bool {
+        get { self.isSelected }
+        set { self.isSelected = newValue }
+    }
     #else
     static var videoSymbol = "􀍉"
     static var videoSlashSymbol = "􀍍"
@@ -66,7 +70,8 @@ internal extension MPButton {
     static var screenShareSymbol = "􀏧"
     static var pinSymbol = "􀎧"
     var isOn: Bool {
-        return self.state == .on
+        get { return self.state == .on }
+        set { self.state = newValue ? .on : .off }
     }
     #endif
 }

--- a/Sources/Agora-UIKit/UIButton+Extensions.swift
+++ b/Sources/Agora-UIKit/UIButton+Extensions.swift
@@ -50,7 +50,7 @@ extension MPButton {
     /// SF Symbol name for camera icon for builtin button
     public static var videoSymbol = "camera.fill"
     /// SF Symbol name for camera alt icon for builtin button
-    public static var muteVideoSelectedSymbol: String? = nil
+    public static var muteVideoSelectedSymbol: String?
     /// SF Symbol name for microphone icon for builtin button
     public static var micSymbol = "mic"
     /// SF Symbol name for microphone alt icon for builtin button
@@ -75,7 +75,7 @@ extension MPButton {
     /// SF Symbol name for camera icon for builtin button
     public static var videoSymbol = "􀌟"
     /// SF Symbol name for camera alt icon for builtin button
-    public static var muteVideoSelectedSymbol: String? = nil
+    public static var muteVideoSelectedSymbol: String?
     /// SF Symbol name for microphone icon for builtin button
     public static var micSymbol = "􀊰"
     /// SF Symbol for microphone alt icon for builtin button

--- a/Sources/Agora-UIKit/UIButton+Extensions.swift
+++ b/Sources/Agora-UIKit/UIButton+Extensions.swift
@@ -41,7 +41,6 @@ extension MPButton {
         ), for: .normal)
         #else
         button.title = unselected
-        print(NSFont.systemFontSize)
         button.font = .systemFont(ofSize: AgoraSettings.buttonIconSize)
         #endif
         return button


### PR DESCRIPTION
- Disable camera or mic before joining channel
- Do not need permission for disabled devices
- Streamlined permission handlers
- Added camera disabled example for AppKit
- Update video icon to alternative SF Symbol (FaceTime restriction)
- Allow customising of builtin icon colours, sizes and spacing