### PR TITLE
move rtm initialiser to utility thread, as it is blocking main thread

### DIFF
--- a/AgoraUIKit_iOS.podspec
+++ b/AgoraUIKit_iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AgoraUIKit_iOS'
-  s.version          = '1.6.6'
+  s.version          = '1.6.7'
   s.summary          = 'Agora video session UIKit template.'
 
   s.description      = <<-DESC

--- a/AgoraUIKit_macOS.podspec
+++ b/AgoraUIKit_macOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AgoraUIKit_macOS'
-  s.version          = '1.6.6'
+  s.version          = '1.6.7'
   s.summary          = 'Agora video session AppKit template.'
 
   s.description      = <<-DESC

--- a/Sources/Agora-UIKit/AgoraUIKit.swift
+++ b/Sources/Agora-UIKit/AgoraUIKit.swift
@@ -22,7 +22,7 @@ public struct AgoraUIKit: Codable {
     /// Framework type of UIKit. "native", "flutter", "reactnative"
     fileprivate(set) var framework: String
     /// Version of UIKit being used
-    static let version = "1.6.6"
+    static let version = "1.6.7"
     /// Framework type of UIKit. "native", "flutter", "reactnative"
     static let framework = "native"
     #if os(iOS)

--- a/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
@@ -326,12 +326,15 @@ extension AgoraVideoViewer {
     open func setupRtmController(joining channel: String) {
         if !self.agSettings.rtmEnabled { return }
         if self.rtmController == nil {
-            self.rtmController = AgoraRtmController(delegate: self)
-            if self.rtmController == nil {
-                AgoraVideoViewer.agoraPrint(.error, message: "Error initialising RTM")
+            DispatchQueue.global(qos: .utility).async {
+                self.rtmController = AgoraRtmController(delegate: self)
+                if self.rtmController == nil {
+                    AgoraVideoViewer.agoraPrint(.error, message: "Error initialising RTM")
+                } else {
+                    self.rtmController?.joinChannel(named: channel)
+                }
             }
         }
-        self.rtmController?.joinChannel(named: channel)
     }
 
     internal func handleAlreadyInChannel(

--- a/Sources/Agora-UIKit/AgoraVideoViewer.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer.swift
@@ -47,6 +47,11 @@ public protocol AgoraVideoViewerDelegate: AnyObject {
     /// A pong request has just come back to the local user, indicating that someone is still present in RTM
     /// - Parameter peerId: RTM ID of the remote user that sent the pong request.
     func incomingPongRequest(from peerId: String)
+    /// State of RTM has changed
+    /// - Parameters:
+    ///   - oldState: Previous state of RTM
+    ///   - newState: New state of RTM
+    func rtmStateChanged(from oldState: AgoraRtmController.RTMStatus, to newState: AgoraRtmController.RTMStatus)
 }
 
 public extension AgoraVideoViewerDelegate {
@@ -65,6 +70,9 @@ public extension AgoraVideoViewerDelegate {
     func extraButtons() -> [NSButton] { [] }
     #endif
     func incomingPongRequest(from peerId: String) {}
+    func rtmStateChanged(
+        from oldState: AgoraRtmController.RTMStatus, to newState: AgoraRtmController.RTMStatus
+    ) {}
 }
 
 /// View to contain all the video session objects, including camera feeds and buttons for settings
@@ -136,6 +144,17 @@ open class AgoraVideoViewer: MPView, SingleVideoViewDelegate {
     internal var currentToken: String? {
         get { self.connectionData.appToken }
         set { self.connectionData.appToken = newValue }
+    }
+
+    /// Status of the RTM Engine
+    var rtmState: AgoraRtmController.RTMStatus {
+        if let rtmc = self.rtmController {
+            return rtmc.rtmStatus
+        } else if self.agSettings.rtmEnabled {
+            return .initFailed
+        } else {
+            return .offline
+        }
     }
 
     lazy internal var floatingVideoHolder: MPCollectionView = {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/AgoraIO-Community/iOS-UIKit/blob/main/CONTRIBUTING.md -->

> Release Version: 1.6.7

## Release Notes

- RTM initialiser moved to utility thread

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [x] The QA checklist below has been completed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- If the RTM connection fails, it block the main thread for ~12 seconds

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- RTM parts moved to utility thread, so main thread (and video call) are not blocked

## Does this introduce a breaking change?

- [x] No

## QA Checklist

### UIKit Update Checklist (Minor or Patch Release)

- [x] Updated version number in `*.podspec` files and `Sources/Agora-UIKit/AgoraUIKit.swift`
- [x] Using the latest version of Agora's Video SDK
- [x] Example apps are all functional
- [x] Core features are still working (both ways across platforms)
	- [x] Camera + Mic muting works for local and remote users
	- [x] Users are added and removed correctly when they join and leave the channel
	- [x] Older versions of the library gracefully handle changes (Create issue if not)
	- [x] Builtin buttons all work as expected
- [x] Any newly deprecated methods are flagged as such inline and in documentation
