### PR TITLE
Bump RTM minimum to ipv4/ipv6 compatible version

### DIFF
--- a/AgoraUIKit_iOS.podspec
+++ b/AgoraUIKit_iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AgoraUIKit_iOS'
-  s.version          = '1.7.0'
+  s.version          = '1.7.1'
   s.summary          = 'Agora video session UIKit template.'
 
   s.description      = <<-DESC
@@ -25,7 +25,7 @@ Use this Pod to create a video UIKit view that can be easily added to your iOS a
 
   s.source_files = 'Sources/Agora-UIKit/*'
   s.dependency 'AgoraRtcEngine_iOS', '~> 3.5.0'
-  s.dependency 'AgoraRtm_iOS', '~> 1.4.8'
+  s.dependency 'AgoraRtm_iOS', '~> 1.4.9'
 
   s.static_framework = true
 end

--- a/AgoraUIKit_macOS.podspec
+++ b/AgoraUIKit_macOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'AgoraUIKit_macOS'
-  s.version          = '1.7.0'
+  s.version          = '1.7.1'
   s.summary          = 'Agora video session AppKit template.'
 
   s.description      = <<-DESC
@@ -26,6 +26,6 @@ Use this Pod to create a video AppKit view that can be easily added to your macO
   s.source_files = 'Sources/Agora-UIKit/*'
   s.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'YES' }
   s.dependency 'AgoraRtcEngine_macOS', '~> 3.5.0'
-  s.dependency 'AgoraRtm_macOS', '~> 1.4.8'
+  s.dependency 'AgoraRtm_macOS', '~> 1.4.9'
   s.static_framework = false
 end

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(
             name: "AgoraRtmKit",
             url: "https://github.com/AgoraIO/AgoraRtm_iOS",
-            from: "1.4.7"
+            from: "1.4.9"
         )
     ],
     targets: [

--- a/Tests/Agora-UIKit-Tests/RtmMessagingTests.swift
+++ b/Tests/Agora-UIKit-Tests/RtmMessagingTests.swift
@@ -39,9 +39,9 @@ final class RtmMessagesTests: XCTestCase {
             XCTAssert(decodedMuteReq.mute == muteReq.mute, "mute invalid!")
             XCTAssert(decodedMuteReq.device == muteReq.device, "device invalid!")
             XCTAssert(decodedMuteReq.isForceful == muteReq.isForceful, "mute invalid!")
-        case .userData(_):
+        case .userData:
             XCTFail("Should not decode to userData")
-        case .genericAction(_):
+        case .genericAction:
             XCTFail("Should not decode to genericAction")
         }
     }


### PR DESCRIPTION
> Release Version: 1.7.1

## Release Notes

- Bump minimum RTM to version that's compatible with ipv4/ipv6 networks

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [x] The QA checklist below has been completed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Not all networks work properly with RTM

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- IPv4/IPv6 networks work correctly

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- If no code has changed, remove this section -->
## QA Checklist

### UIKit Update Checklist (Minor or Patch Release)

- [x] Updated version number in `*.podspec` files and `Sources/Agora-UIKit/AgoraUIKit.swift`
- [x] Using the latest version of Agora's Video SDK
- [x] Example apps are all functional
- [x] Core features are still working (both ways across platforms)
	- [x] Camera + Mic muting works for local and remote users
	- [x] Users are added and removed correctly when they join and leave the channel
	- [x] Older versions of the library gracefully handle changes (Create issue if not)
	- [x] Builtin buttons all work as expected
- [x] Any newly deprecated methods are flagged as such inline and in documentation
