### PR TITLE
Multi Dependencies SwiftPM Fix

### DIFF
--- a/AgoraRtmControl_iOS.podspec
+++ b/AgoraRtmControl_iOS.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'AgoraRtmControl_iOS'
   s.module_name      = 'AgoraRtmControl'
-  s.version          = ENV['LIB_VERSION'] || '1.8.1'
+  s.version          = ENV['LIB_VERSION'] || '1.8.2'
   s.summary          = 'Agora Real-time Messaging Wrapper.'
 
   s.description      = <<-DESC

--- a/AgoraRtmControl_macOS.podspec
+++ b/AgoraRtmControl_macOS.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'AgoraRtmControl_macOS'
   s.module_name      = 'AgoraRtmControl'
-  s.version          = ENV['LIB_VERSION'] || '1.8.1'
+  s.version          = ENV['LIB_VERSION'] || '1.8.2'
   s.summary          = 'Agora Real-time Messaging Wrapper.'
 
   s.description      = <<-DESC

--- a/AgoraUIKit_iOS.podspec
+++ b/AgoraUIKit_iOS.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'AgoraUIKit_iOS'
   s.module_name      = 'AgoraUIKit'
-  s.version          = ENV['LIB_VERSION'] || '1.8.1'
+  s.version          = ENV['LIB_VERSION'] || '1.8.2'
   s.summary          = 'Agora video session UIKit template.'
 
   s.description      = <<-DESC

--- a/AgoraUIKit_macOS.podspec
+++ b/AgoraUIKit_macOS.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'AgoraUIKit_macOS'
   s.module_name      = 'AgoraUIKit'
-  s.version          = ENV['LIB_VERSION'] || '1.8.1'
+  s.version          = ENV['LIB_VERSION'] || '1.8.2'
   s.summary          = 'Agora video session AppKit template.'
 
   s.description      = <<-DESC

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "AgoraUIKit_iOS",
     platforms: [.iOS(.v13)],
     products: [
-        .library(name: "AgoraUIKit", targets: ["AgoraUIKit"]),
+        .library(name: "AgoraUIKit", targets: ["AgoraUIKit", "AgoraRtmControl"]),
+        .library(name: "AgoraUIKitBasic", targets: ["AgoraUIKit"]),
         .library(name: "AgoraRtmControl", targets: ["AgoraRtmControl"])
     ],
     dependencies: [

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
     <img src="https://github.com/AgoraIO-Community/iOS-UIKit/workflows/Pod%20Lint/badge.svg"/>
     <img src="https://github.com/AgoraIO-Community/iOS-UIKit/workflows/swiftlint/badge.svg"/></br>
     <img src="https://img.shields.io/badge/platform-iOS%20|%20macOS-lightgrey"/>
-    <img src="https://img.shields.io/github/v/release/AgoraIO-Community/iOS-UIKit?color=orange&label=SwiftPM&logo=swift"/>
-    <img src="https://img.shields.io/cocoapods/v/AgoraUIKit_iOS?label=CocoaPods"/>
+    <img src="https://img.shields.io/github/v/release/AgoraIO-Community/iOS-UIKit?color=orange&label=Stable%20Release&logo=swift"/>
+    <img src="https://img.shields.io/cocoapods/v/AgoraUIKit_iOS?label=Pre-release"/>
     <a href="https://www.agora.io/en/join-slack/">
         <img src="https://img.shields.io/badge/slack-@RTE%20Dev-blue.svg?logo=slack">
     </a>
@@ -15,7 +15,8 @@ Instantly integrate Agora in your own application or prototype using iOS or macO
 <p align="center">
   <img src="https://github.com/AgoraIO-Community/iOS-UIKit/raw/main/media/agora-uikit-banner.png"/>
 </p>
-[More information available on this repo\'s Wiki](https://github.com/AgoraIO-Community/iOS-UIKit/wiki)
+
+[More information available on this repo's Wiki](https://github.com/AgoraIO-Community/iOS-UIKit/wiki)
 
 [Click here for full documentation](https://agoraio-community.github.io/iOS-UIKit/)
 

--- a/Sources/Agora-UIKit/AgoraUIKit+AgoraRtmController+Extensions.swift
+++ b/Sources/Agora-UIKit/AgoraUIKit+AgoraRtmController+Extensions.swift
@@ -39,7 +39,7 @@ extension AgoraVideoViewer {
         }
         var iOSUInt: UInt? {
             if let rtcId = rtcId {
-                return UInt(UInt32(bitPattern: Int32(rtcId)))
+                return AgoraUIKit.intToUInt(rtcId)
             }
             return nil
         }
@@ -166,7 +166,7 @@ extension AgoraVideoViewer: RtmControllerDelegate {
         self.sendPersonalData(to: member.userId)
     }
     public func personalData() -> some Codable {
-        let safeRtcId = Int32(self.rtcId ?? 0)
+        let safeRtcId = AgoraUIKit.uintToInt(self.rtcId ?? 0)
         return UserData(
             rtmId: self.rtmId,
             rtcId: safeRtcId == 0 ? nil : Int(safeRtcId),

--- a/Sources/Agora-UIKit/AgoraUIKit+AgoraRtmController+MuteRequests.swift
+++ b/Sources/Agora-UIKit/AgoraUIKit+AgoraRtmController+MuteRequests.swift
@@ -60,7 +60,7 @@ extension AgoraVideoViewer {
             self.isForceful = isForceful
         }
         var iOSUInt: UInt? {
-            return UInt(UInt32(bitPattern: Int32(rtcId)))
+            return AgoraUIKit.intToUInt(self.rtcId)
         }
     }
 
@@ -95,7 +95,7 @@ extension AgoraVideoViewer {
             return
         }
         // This is to make sure the user ID is understood across platforms.
-        let safeRtcId = Int(Int32(bitPattern: UInt32(rtcId)))
+        let safeRtcId = AgoraUIKit.uintToInt(rtcId)
         let muteReq = MuteRequest(rtcId: safeRtcId, mute: mute, device: device, isForceful: isForceful)
         self.rtmController?.sendCodable(message: muteReq, user: rtcId) { sendStatus in
             if sendStatus == .ok {

--- a/Sources/Agora-UIKit/AgoraUIKit.swift
+++ b/Sources/Agora-UIKit/AgoraUIKit.swift
@@ -22,7 +22,7 @@ public struct AgoraUIKit: Codable {
     /// Framework type of UIKit. "native", "flutter", "reactnative"
     fileprivate(set) var framework: String
     /// Version of UIKit being used
-    static let version = "1.8.1"
+    static let version = "1.8.2"
     /// Framework type of UIKit. "native", "flutter", "reactnative"
     static let framework = "native"
     #if os(iOS)
@@ -47,5 +47,10 @@ public struct AgoraUIKit: Codable {
             framework: \(framework)
         """
     }
-
+    public static func uintToInt(_ uint: UInt) -> Int {
+        Int(Int32(bitPattern: UInt32(uint)))
+    }
+    public static func intToUInt(_ userInt: Int) -> UInt {
+        UInt(UInt32(bitPattern: Int32(userInt)))
+    }
 }

--- a/Sources/Agora-UIKit/AgoraVideoViewer+AgoraRtcEngineDelegate.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+AgoraRtcEngineDelegate.swift
@@ -8,7 +8,6 @@
 import AgoraRtcKit
 
 extension AgoraVideoViewer: AgoraRtcEngineDelegate {
-
     /// Called when the user role successfully changes
     /// - Parameters:
     ///   - engine: AgoraRtcEngine of this session.
@@ -163,6 +162,24 @@ extension AgoraVideoViewer: AgoraRtcEngineDelegate {
             engine, remoteVideoStateChangedOfUid: uid, state: state,
             reason: reason, elapsed: elapsed
         )
+    }
+
+    /**
+     Occurs when the local user successfully joins a specified channel.
+     - Parameters:
+        - engine: AgoraRtcEngineKit object
+        - channel: The channel name.
+        - uid: The user ID.
+        - elapsed: The time elapsed (ms) from the local user calling `joinChannelByToken` until this event occurs.
+     */
+    open func rtcEngine(_ engine: AgoraRtcEngineKit, didJoinChannel channel: String, withUid uid: UInt, elapsed: Int) {
+        self.userID = uid
+        if self.userRole == .broadcaster { self.addLocalVideo() }
+        #if canImport(AgoraRtmControl)
+        self.setupRtmController(joining: channel)
+        #endif
+        self.delegate?.joinedChannel(channel: channel)
+        self.agoraSettings.rtcDelegate?.rtcEngine?(engine, didJoinChannel: channel, withUid: uid, elapsed: elapsed)
     }
 
     /**

--- a/Sources/Agora-UIKit/AgoraVideoViewer+RtcEngineDelegateOverflow.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+RtcEngineDelegateOverflow.swift
@@ -226,10 +226,6 @@ extension AgoraVideoViewer {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, didApiCallExecute: error, api: api, result: result)
     }
 
-    open func rtcEngine(_ engine: AgoraRtcEngineKit, didJoinChannel channel: String, withUid uid: UInt, elapsed: Int) {
-        self.agoraSettings.rtcDelegate?.rtcEngine?(engine, didJoinChannel: channel, withUid: uid, elapsed: elapsed)
-    }
-
     open func rtcEngine(_ engine: AgoraRtcEngineKit, didRejoinChannel channel: String, withUid uid: UInt, elapsed: Int) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, didRejoinChannel: channel, withUid: uid, elapsed: elapsed)
     }
@@ -307,22 +303,22 @@ extension AgoraVideoViewer {
     public func rtcEngine(_ engine: AgoraRtcEngineKit, didRequest info: AgoraRtcAudioFileInfo, error: AgoraAudioFileInfoError) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, didRequest: info, error: error)
     }
-    public func rtcEngine(_ engine: AgoraRtcEngineKit, wlAccStats currentStats: AgoraWlAccStats, averageStats: AgoraWlAccStats) {
+    open func rtcEngine(_ engine: AgoraRtcEngineKit, wlAccStats currentStats: AgoraWlAccStats, averageStats: AgoraWlAccStats) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, wlAccStats: currentStats, averageStats: averageStats)
     }
-    public func rtcEngine(_ engine: AgoraRtcEngineKit, wlAccMessage reason: AgoraWlAccReason, action: AgoraWlAccAction, wlAccMsg: String) {
+    open func rtcEngine(_ engine: AgoraRtcEngineKit, wlAccMessage reason: AgoraWlAccReason, action: AgoraWlAccAction, wlAccMsg: String) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, wlAccMessage: reason, action: action, wlAccMsg: wlAccMsg)
     }
-    public func rtcEngine(_ engine: AgoraRtcEngineKit, reportAudioDeviceTestVolume volumeType: AgoraAudioDeviceTestVolumeType, volume: Int) {
+    open func rtcEngine(_ engine: AgoraRtcEngineKit, reportAudioDeviceTestVolume volumeType: AgoraAudioDeviceTestVolumeType, volume: Int) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, reportAudioDeviceTestVolume: volumeType, volume: volume)
     }
-    public func rtcEngine(_ engine: AgoraRtcEngineKit, didClientRoleChangeFailed reason: AgoraClientRoleChangeFailedReason, currentRole: AgoraClientRole) {
+    open func rtcEngine(_ engine: AgoraRtcEngineKit, didClientRoleChangeFailed reason: AgoraClientRoleChangeFailedReason, currentRole: AgoraClientRole) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, didClientRoleChangeFailed: reason, currentRole: currentRole)
     }
-    public func rtcEngine(_ engine: AgoraRtcEngineKit, snapshotTaken channel: String, uid: UInt, filePath: String, width: Int, height: Int, errCode: Int) {
+    open func rtcEngine(_ engine: AgoraRtcEngineKit, snapshotTaken channel: String, uid: UInt, filePath: String, width: Int, height: Int, errCode: Int) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, snapshotTaken: channel, uid: uid, filePath: filePath, width: width, height: height, errCode: errCode)
     }
-    public func rtcEngine(_ engine: AgoraRtcEngineKit, didProxyConnected channel: String, withUid uid: UInt, proxyType: AgoraProxyType, localProxyIp: String, elapsed: Int) {
+    open func rtcEngine(_ engine: AgoraRtcEngineKit, didProxyConnected channel: String, withUid uid: UInt, proxyType: AgoraProxyType, localProxyIp: String, elapsed: Int) {
         self.agoraSettings.rtcDelegate?.rtcEngine?(engine, didProxyConnected: channel, withUid: uid, proxyType: proxyType, localProxyIp: localProxyIp, elapsed: elapsed)
     }
 }

--- a/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
+++ b/Sources/Agora-UIKit/AgoraVideoViewer+VideoControl.swift
@@ -312,14 +312,7 @@ extension AgoraVideoViewer {
             byToken: token,
             channelId: channel,
             info: nil, uid: self.userID
-        ) { [weak self] _, uid, _ in
-            self?.userID = uid
-            if self?.userRole == .broadcaster { self?.addLocalVideo() }
-            self?.delegate?.joinedChannel(channel: channel)
-            #if canImport(AgoraRtmControl)
-            self?.setupRtmController(joining: channel)
-            #endif
-        }
+        )
     }
 
     #if canImport(AgoraRtmControl)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/AgoraIO-Community/iOS-UIKit/blob/main/CONTRIBUTING.md -->

> Release Version: 1.8.2

## Release Notes

- Fix SwiftPM Caching Issue - AgoraUIKit includes both libraries, AgoraUIKitBasic doesn't have RTM
- Internally moved join success code to the callback delegate

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [x] The QA checklist below has been completed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Other (please describe): 

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- If no code has changed, remove this section -->
## QA Checklist

### UIKit Update Checklist (Minor or Patch Release)

- [x] Updated version number in `*.podspec` files and `Sources/Agora-UIKit/AgoraUIKit.swift`
- [x] Using the latest version of Agora's Video SDK
- [x] Example apps are all functional
- [x] Core features are still working (both ways across platforms)
	- [x] Camera + Mic muting works for local and remote users
	- [x] Users are added and removed correctly when they join and leave the channel
	- [x] Older versions of the library gracefully handle changes (Create issue if not)
	- [x] Builtin buttons all work as expected
- [x] Any newly deprecated methods are flagged as such inline and in documentation
